### PR TITLE
Update tree-sitter submodule to Pulsar fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/tree-sitter"]
 	path = vendor/tree-sitter
-	url = https://github.com/atom/tree-sitter.git
+	url = https://github.com/pulsar-edit/tree-sitter.git


### PR DESCRIPTION
This updates the upstream URL of the tree-sitter submodule to be the Pulsar fork, and also sets the submodule reference to 4ac56b4f which is the commit hash of [tree-sitter/master](https://github.com/pulsar-edit/tree-sitter/compare/master...pulsar-edit:tree-sitter:4ac56b4f)